### PR TITLE
ci: daily apt cache-bust + hash-aware CVE issue reopen

### DIFF
--- a/.github/scripts/file-cve-issue.js
+++ b/.github/scripts/file-cve-issue.js
@@ -1,10 +1,14 @@
 // Shared helper for the gating jobs in mirror-build.yml.
 //
-// Three kinds:
+// Five kinds:
 //   - 'block'           — Trivy CVE found at build time, push blocked
 //   - 'rescan'          — Trivy CVE detected post-release in the published image
 //   - 'override-review' — upstream Dockerfile changed since last review; the
 //                         override may need updating before the next build
+//   - 'block-resolved'  — Trivy clean at build time; close any open `block`
+//                         issue for this tag (image now passes the gate)
+//   - 'rescan-resolved' — Trivy clean on rescan; close any open `rescan` issue
+//                         for the previously-built tag
 //
 // Idempotency keys are stored as hidden HTML comments in the issue body:
 //
@@ -14,11 +18,21 @@
 //   <!-- findings-cves:CVE-x,CVE-y,... -->        sorted CVE list (CVE kinds only)
 //   <!-- drift-files:path1,path2,... -->          changed Dockerfile paths (override-review only)
 //
-// Behavior:
+// Behavior (filing kinds — block, rescan, override-review):
 //   - No matching open issue       → create new (returns { blocked: true })
 //   - Open issue, hash unchanged   → silent no-op  (returns { blocked: true })
 //   - Open issue, hash changed     → update body + post diff comment (returns { blocked: true })
-//   - Closed issue with this marker → silent no-op  (returns { blocked: false })
+//   - Closed override-review issue → silent no-op (closing an override-review
+//     IS the maintainer's approval, so don't re-open)
+//   - Closed CVE issue (block/rescan), hash unchanged → silent no-op (the
+//     maintainer triaged this exact finding-set; honor the close)
+//   - Closed CVE issue (block/rescan), hash changed → REOPEN + update body +
+//     post diff comment (findings have shifted since the close — likely new
+//     CVEs landed for the same tag, the maintainer needs to see them)
+//
+// Behavior (resolving kinds — block-resolved, rescan-resolved):
+//   - Matching open issue          → comment "resolved by run X" + close (returns { blocked: false })
+//   - No matching issue, or closed → silent no-op (returns { blocked: false })
 //
 // `blocked` lets callers decide whether to fail the workflow step. CVE callers
 // have a separate exit-1 step gated on Trivy outcome; override-review callers
@@ -250,7 +264,7 @@ function extractMarker(body, name) {
 
 module.exports = async function fileCveIssue({ github, context, core, opts }) {
   const { kind, tag, upstream, image, severity, dockerfileSource, jsonPath, jsonPaths, driftPath } = opts;
-  if (!['block', 'rescan', 'override-review'].includes(kind)) {
+  if (!['block', 'rescan', 'override-review', 'block-resolved', 'rescan-resolved'].includes(kind)) {
     throw new Error(`Invalid kind: ${kind}`);
   }
   if (!tag) {
@@ -259,6 +273,42 @@ module.exports = async function fileCveIssue({ github, context, core, opts }) {
 
   const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
   const securityUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/security`;
+
+  // Resolving kinds run before the rest of the filing logic — they don't
+  // produce findings or render a body, just look up an open issue with the
+  // matching marker and close it. Idempotent: a re-run on an already-closed
+  // (or never-existed) issue is a no-op.
+  if (kind === 'block-resolved' || kind === 'rescan-resolved') {
+    const baseKind = kind === 'block-resolved' ? 'block' : 'rescan';
+    const marker = `<!-- mirror-build:cve-${baseKind}:${tag} -->`;
+    const existing = await findExistingIssue({ github, context, marker, labelFilter: 'cve' });
+    if (!existing) {
+      core.info(`No ${baseKind} issue found for tag ${tag} — nothing to clear.`);
+      return { blocked: false };
+    }
+    if (existing.state === 'closed') {
+      core.info(`${baseKind} issue #${existing.number} for tag ${tag} already closed — no-op.`);
+      return { blocked: false };
+    }
+    const reason = baseKind === 'block'
+      ? `Trivy now scans \`${image}:${tag}\` clean; image was pushed.`
+      : `Trivy rescan of \`${image}:${tag}\` is now clean.`;
+    await github.rest.issues.createComment({
+      owner: context.repo.owner,
+      repo: context.repo.repo,
+      issue_number: existing.number,
+      body: `Resolved by [run ${context.runId}](${runUrl}). ${reason} Closing.`,
+    });
+    await github.rest.issues.update({
+      owner: context.repo.owner,
+      repo: context.repo.repo,
+      issue_number: existing.number,
+      state: 'closed',
+      state_reason: 'completed',
+    });
+    core.info(`Closed ${baseKind} issue #${existing.number} for tag ${tag}.`);
+    return { blocked: false };
+  }
 
   // Marker, label, title, payload are all kind-specific.
   let marker, title, labels, labelFilter, findings, drift, hashForLog, summaryForLog;
@@ -301,14 +351,32 @@ module.exports = async function fileCveIssue({ github, context, core, opts }) {
     return { blocked: true };
   }
 
-  if (existing.state === 'closed') {
-    core.info(`Found closed issue #${existing.number} for ${marker} — respecting maintainer decision; not re-opening.`);
-    return { blocked: false };
-  }
-
+  // Track whether the existing issue was closed so we can word the comment
+  // and the update payload differently. The closed-issue branch below may
+  // either short-circuit (no-op) or reopen and fall through to the update
+  // path that handles open issues with stale bodies.
+  const wasClosed = existing.state === 'closed';
   const oldHash = extractMarker(existing.body, 'findings-sha256');
   const newHash = (kind === 'override-review' ? drift.hash : findings.hash);
-  if (oldHash === newHash) {
+
+  if (wasClosed) {
+    if (kind === 'override-review') {
+      // Closing an override-review IS the maintainer's "I've reviewed this"
+      // signal — re-opening would override that decision. Honor it.
+      core.info(`Found closed override-review #${existing.number} — respecting maintainer decision; not re-opening.`);
+      return { blocked: false };
+    }
+    // CVE kinds: closing only means "I've seen this finding-set" — it does
+    // NOT mean the CVEs are fixed. If new findings show up against the same
+    // tag (e.g. a new advisory landed overnight), the maintainer needs to be
+    // pulled back in. Honor the close only when the finding-set is bit-for-
+    // bit identical to what they last saw.
+    if (oldHash === newHash) {
+      core.info(`Closed CVE issue #${existing.number} matches current findings (hash ${newHash}); honoring close.`);
+      return { blocked: false };
+    }
+    core.info(`Reopening CVE issue #${existing.number}: findings changed since close (${oldHash || 'none'} → ${newHash}).`);
+  } else if (oldHash === newHash) {
     core.info(`Open issue #${existing.number} already reflects current state (hash ${newHash}). No-op.`);
     return { blocked: true };
   }
@@ -318,10 +386,18 @@ module.exports = async function fileCveIssue({ github, context, core, opts }) {
     repo: context.repo.repo,
     issue_number: existing.number,
     body,
+    // Reopen iff we explicitly decided to above. For already-open issues the
+    // GitHub API treats `state` as a no-op idempotent set, so passing 'open'
+    // is harmless either way — but being explicit keeps the intent clear.
+    state: 'open',
   });
 
   // Diff comment: kind-specific summary of what changed since last update.
-  const lines = [`State changed in [run ${context.runId}](${runUrl}):`, ``];
+  // Lead with "Reopened" wording when applicable so the maintainer sees
+  // immediately why the issue is back in their inbox.
+  const lines = wasClosed
+    ? [`Reopened by [run ${context.runId}](${runUrl}) — findings changed since this issue was closed:`, ``]
+    : [`State changed in [run ${context.runId}](${runUrl}):`, ``];
   if (kind === 'override-review') {
     const oldFilesRaw = extractMarker(existing.body, 'drift-files');
     const oldFiles = new Set(oldFilesRaw ? oldFilesRaw.split(',').filter(Boolean) : []);

--- a/.github/workflows/mirror-build.yml
+++ b/.github/workflows/mirror-build.yml
@@ -345,6 +345,17 @@ jobs:
       - name: Set up Buildx
         uses: docker/setup-buildx-action@v3
 
+      # Emit today's UTC date for use as APT_REFRESH build-arg. BuildKit hashes
+      # cache layers on (parent layer + RUN command string) — the apt repo
+      # state is not part of that hash, so an unchanged Dockerfile re-uses
+      # the cached apt layer indefinitely and never picks up new Debian
+      # security updates. Threading this date into the apt-install RUN
+      # invalidates the layer once per UTC day, which matches the Debian
+      # security cadence we promise. Within a day, cache reuse is unaffected.
+      - name: Compute APT_REFRESH date
+        id: apt-refresh
+        run: echo "date=$(date -u +%Y-%m-%d)" >> "$GITHUB_OUTPUT"
+
       - name: Build image (load, no push)
         id: build
         uses: docker/build-push-action@v6
@@ -357,8 +368,12 @@ jobs:
           # binary's Main.Version. Overrides that don't declare ARG VERSION
           # ignore this silently — backward-compatible with plain upstream
           # Dockerfiles. See README "Module-path patching".
+          # APT_REFRESH busts the apt-install layer cache once per UTC day
+          # (see "Compute APT_REFRESH date" step). Overrides that don't
+          # declare ARG APT_REFRESH ignore it silently.
           build-args: |
             VERSION=${{ needs.check-upstream.outputs.new_tag }}
+            APT_REFRESH=${{ steps.apt-refresh.outputs.date }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
@@ -444,6 +459,28 @@ jobs:
               },
             });
 
+      # Inverse gate: Trivy passed for this tag this run, so any open `block`
+      # issue from a previous (failing) run for the same tag is now stale.
+      # The helper looks it up by marker, posts a "resolved by run X" comment,
+      # and closes it. No-op if no such issue exists or it's already closed.
+      - name: Close CVE issue if scan clean
+        if: steps.trivy-scan.outcome == 'success' && steps.trivy-fs.outcome == 'success'
+        uses: actions/github-script@v7
+        env:
+          NEW_TAG: ${{ needs.check-upstream.outputs.new_tag }}
+          IMG:     ${{ env.IMAGE_NAME }}
+        with:
+          script: |
+            const fileCveIssue = require('./.github/scripts/file-cve-issue.js');
+            await fileCveIssue({
+              github, context, core,
+              opts: {
+                kind: 'block-resolved',
+                tag: process.env.NEW_TAG,
+                image: process.env.IMG,
+              },
+            });
+
       - name: Upload audit bundle
         uses: actions/upload-artifact@v4
         if: always()
@@ -477,6 +514,7 @@ jobs:
             ${{ env.IMAGE_NAME }}:latest
           build-args: |
             VERSION=${{ needs.check-upstream.outputs.new_tag }}
+            APT_REFRESH=${{ steps.apt-refresh.outputs.date }}
           cache-from: type=gha
 
       # --- Open a PR with the digest pin -------------------------------------
@@ -688,6 +726,27 @@ jobs:
                 image: process.env.IMG,
                 severity: process.env.SEV,
                 jsonPath: 'trivy-rescan.json',
+              },
+            });
+
+      # Inverse gate: rescan passed clean for last_tag, so any open `rescan`
+      # issue from a previous nightly is stale. Same close-on-resolve helper
+      # call as in the build job, with the rescan marker shape.
+      - name: Close rescan issue if rescan clean
+        if: steps.last.outputs.should_scan == 'true' && steps.trivy-rescan.outcome == 'success'
+        uses: actions/github-script@v7
+        env:
+          LAST_TAG: ${{ steps.last.outputs.last_tag }}
+          IMG:      ${{ env.IMAGE_NAME }}
+        with:
+          script: |
+            const fileCveIssue = require('./.github/scripts/file-cve-issue.js');
+            await fileCveIssue({
+              github, context, core,
+              opts: {
+                kind: 'rescan-resolved',
+                tag: process.env.LAST_TAG,
+                image: process.env.IMG,
               },
             });
 

--- a/dockerfiles/Dockerfile.override
+++ b/dockerfiles/Dockerfile.override
@@ -121,9 +121,19 @@ LABEL org.opencontainers.image.source="https://github.com/plausible/analytics" \
 
 RUN adduser -S -H -u 999 -G nogroup plausible
 
+# APT_REFRESH is a daily UTC date string forwarded by the CI workflow.
+# Despite the name (sized for the apt-using overrides in this pipeline),
+# the same mechanism is needed here for apk: BuildKit hashes RUN layers
+# on (parent + command string), so an unchanged Dockerfile would re-use
+# the cached `apk upgrade` layer indefinitely and never pick up new
+# Alpine security advisories. Threading the date into the command bumps
+# the hash once per UTC day. Default `unset` keeps local builds working.
+ARG APT_REFRESH=unset
+
 # apk upgrade picks up any base-image CVE fixes published since the
 # pinned digest was cut. Trivy reads the resulting installed-package set.
-RUN apk upgrade --no-cache && \
+RUN echo "apt-refresh=${APT_REFRESH}" > /etc/.apt-refresh && \
+    apk upgrade --no-cache && \
     apk add --no-cache openssl ncurses libstdc++ libgcc ca-certificates
 
 COPY --from=buildcontainer --chmod=555 /app/_build/${MIX_ENV}/rel/plausible /app


### PR DESCRIPTION
Backport of mirror-uptime-kuma#7 to keep all repos on the same pipeline state.

- Daily APT_REFRESH cache-bust so unchanged Dockerfiles still pick up Debian security updates.
- Hash-aware CVE issue reopen: closed CVE issues are reopened when findings change rather than being silently honored.
- file-cve-issue.js helper consolidated to support block / rescan / override-review / block-resolved / rescan-resolved kinds.