### PR TITLE
override: drop storybook copy for upstream v3.2.1 (security release)

### DIFF
--- a/dockerfiles/Dockerfile.override
+++ b/dockerfiles/Dockerfile.override
@@ -83,7 +83,6 @@ COPY tracker ./tracker
 COPY priv ./priv
 COPY lib ./lib
 COPY extra ./extra
-COPY storybook ./storybook
 
 RUN npm run deploy --prefix ./tracker && \
     mix assets.deploy && \


### PR DESCRIPTION
## Summary

Plausible released [**v3.2.1**](https://github.com/plausible/analytics/releases/tag/v3.2.1) on 2026-05-15 as a **security fix**: the `HTTP /storybook` endpoint allowed RCE with the application user's privileges under certain conditions. All Plausible CE versions v3.0.0–v3.2.0 are affected — including our currently-published `:v3.2.0`.

Upstream's fix removes the storybook endpoint entirely and deletes the `storybook/` source tree from the repo. The override-review gate ([#6](https://github.com/THEKROLL-LTD/mirror-Plausible/issues/6)) flagged the corresponding `Dockerfile` diff (the upstream `COPY storybook ./storybook` line was removed).

Our `dockerfiles/Dockerfile.override` still has that COPY, which would now fail with "file not found in build context" against v3.2.1. This PR drops the line to match upstream. No other behaviour change — the override remains byte-equivalent to upstream up to base-image digest pinning, certbot removal, and OCI labels.

## Test plan

- [ ] Merge to `main`
- [ ] Close #6 (override-gate acknowledgement)
- [ ] `gh workflow run mirror-build.yml` on the default branch
- [ ] Verify the build pushes `ghcr.io/thekroll-ltd/plausible:v3.2.1`, `:latest`, and the SHA pin
- [ ] Confirm bot opens the post-build `mirror-build/v3.2.1` PR with refreshed `image-pin.yml` / `.last-built-tag`