### PR TITLE
ci: rescan keeps CVE issue body current and comments only on change

### DIFF
--- a/.github/scripts/file-cve-issue.js
+++ b/.github/scripts/file-cve-issue.js
@@ -24,13 +24,17 @@
 //   <!-- findings-cves:CVE-x,CVE-y,... -->    sorted CVE list (for diff comments)
 //   <!-- drift-files:path1,path2,... -->      changed Dockerfile paths (override-review only)
 //
-// Pending-build override:
-//   When a rescan runs and finds the issue with last-scan-source=build AND
-//   last-scan-status=open (build is currently blocked, hasn't pushed), the
-//   rescan does NOT update the body. It posts a comment with its findings so
-//   the audit trail is preserved, but the body keeps showing the pending
-//   build's view. Build retains write priority on the body until it resolves
-//   (push succeeds or maintainer closes the issue).
+// Body ownership & the blocked-build invariant:
+//   The body always reflects the most recent scan (build or rescan), stamped
+//   with its source — so a reader sees the *current* findings, and the comment
+//   thread carries the history. A rescan that runs while a build is blocked
+//   (last-scan-source=build, last-scan-status=open) therefore updates the body
+//   to the deployed image's current findings and comments ONLY when the
+//   finding-set changed; it never re-posts an identical finding-set every
+//   night. The single invariant preserved across this: a rescan never CLOSES
+//   an issue while the build is still blocked — the build owns the close/push
+//   decision. If the deployed image scans clean in that state the issue simply
+//   stays open and silent until the build resolves.
 //
 // Legacy migration:
 //   First invocation against a tag also checks for the pre-unification markers
@@ -45,12 +49,13 @@
 //   - Existing issue, body changed   → update body + diff comment
 //   - Existing closed, hash matches  → honor close (maintainer triaged this set)
 //   - Existing closed, hash differs  → reopen + update body + diff comment
-//   - Pending-build override active  → rescan posts comment only, body untouched
+//   - Rescan while build blocked     → same rules: update body to deployed-image
+//                                      findings, comment only when the set changed
 //
 // Behavior (cve-resolved):
 //   - No matching issue              → no-op (nothing to clean up)
 //   - Open issue, build resolution   → update body to 'resolved' + close
-//   - Open issue, rescan resolution while build pending → comment only (build owns body)
+//   - Open issue, rescan clean while build pending → keep open, silent (build owns close)
 //   - Already closed                 → no-op
 //
 // Behavior (override-review): unchanged from previous version.
@@ -517,14 +522,13 @@ module.exports = async function fileCveIssue({ github, context, core, opts }) {
     }
 
     if (source === 'rescan' && currentSource === 'build' && currentStatus === 'open') {
-      // Build currently blocked — rescan can only annotate, not close.
-      await github.rest.issues.createComment({
-        owner: context.repo.owner,
-        repo: context.repo.repo,
-        issue_number: existing.number,
-        body: `Rescan [run ${context.runId}](${runUrl}) found the deployed image clean against \`${image}:${tag}\`, but a new build is currently blocked. Issue stays open until build resolves.`,
-      });
-      core.info(`Rescan-clean while build pending — annotated #${existing.number}, body untouched.`);
+      // Build wrote the body and hasn't pushed — it owns the close decision, so
+      // the rescan must not close here. A clean deployed image while a rebuild
+      // is blocked is the expected steady state, not an event, so we stay
+      // silent rather than re-posting the same note every night. The build
+      // closes this when it resolves; a future dirty rescan updates the body
+      // via the cve-findings path.
+      core.info(`Rescan-clean while build pending — keeping #${existing.number} open, no comment.`);
       return { blocked: false };
     }
 
@@ -578,24 +582,13 @@ module.exports = async function fileCveIssue({ github, context, core, opts }) {
   const currentSource = extractMarker(existing.body, 'last-scan-source');
   const currentStatus = extractMarker(existing.body, 'last-scan-status');
 
-  // Pending-build override: rescan never overwrites a body that's currently
-  // owned by an open build state. It posts a comment so the audit trail
-  // captures the rescan result, but the body stays build-flavored until the
-  // build resolves.
-  if (source === 'rescan' && currentSource === 'build' && currentStatus === 'open') {
-    const summary = findings.cves.length === 0
-      ? 'rescan clean'
-      : `${findings.cves.length} CVE${findings.cves.length === 1 ? '' : 's'}: ${findings.cves.join(', ')}`;
-    await github.rest.issues.createComment({
-      owner: context.repo.owner,
-      repo: context.repo.repo,
-      issue_number: existing.number,
-      body: `Rescan [run ${context.runId}](${runUrl}) against deployed image \`${image}:${tag}\` — ${summary}.\n\nBody unchanged because a new build is currently blocked (build view takes precedence on the body).`,
-    });
-    core.info(`Pending-build override active — rescan posted comment on #${existing.number}, body untouched.`);
-    return { blocked: true };
-  }
-
+  // A rescan that runs while a build is blocked (currentSource=build,
+  // currentStatus=open) is NOT special-cased here: it flows through the same
+  // change-detection below as any other update. The body is rewritten to the
+  // deployed image's current findings (stamped source=rescan), and a comment
+  // is posted only when the finding-set actually changed — the no-op guard
+  // keeps repeated identical rescans silent. The build keeps the close/push
+  // decision via the cve-resolved path; nothing here closes the issue.
   const oldHash = extractMarker(existing.body, 'findings-sha256');
   const newHash = findings.hash;
   const wasClosed = existing.state === 'closed';


### PR DESCRIPTION
## Problem
The **pending-build override** in `.github/scripts/file-cve-issue.js` did two things while a build was blocked:
1. **Froze the issue body** to the build-time view — so the body advertised only the build-time finding-set even as the deployed image diverged.
2. **Commented on every nightly rescan**, regardless of whether the finding-set changed.

On `mirror-uptime-kuma#18` this meant the identical 31-CVE comment was posted **every night**, while the body still showed only the 5 build-time CVEs — understating the live exposure. The "audit trail" rationale is backwards: a real audit trail is **body = current findings, comments = the history of changes**.

## Change
Remove the override and let a rescan flow through the existing change-detection path:

- **cve-findings** — a rescan while a build is blocked updates the body to the **deployed image's current findings** (stamped `source=rescan`) and posts a comment **only when the finding-set actually changed**. The existing no-op guard (`oldHash === newHash && currentSource === source`) keeps repeated identical rescans **silent**.
- **cve-resolved** — a **clean** rescan while a build is blocked keeps the issue **open** but **silent**, instead of re-posting "a new build is currently blocked" every night.

## Invariant preserved
A rescan **never closes** an issue while the build is blocked — the build still owns the close/push decision. `closeAssociatedMirrorBuildPR` is a documented no-op when no rollout PR exists, so the build-blocked path is unaffected; in the cases where a rollout PR *does* exist, auto-closing it on a dirty rescan is the already-intended behavior.

## Trade-off (intentional)
While a rebuild is blocked, the body reflects the **deployed image** (image-only rescan) rather than the build-time **fs+image** scan. The build-time finding-set stays in the **comment history**. This matches the principle "body = current state, comments = history". Flagged here so it's an explicit review decision.

## Sync
Template-first; identical patch synced to all forks. Script is byte-identical across template + Gokapi + Plausible + uptime-kuma + Beszel. `node --check` passes everywhere.